### PR TITLE
Bump balena-sdk to v12.12.0 to stop using image maker endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "node"
+  - "10"
   - "8"
   - "6"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tmp": "^0.0.31"
   },
   "dependencies": {
-    "balena-sdk": "^11.0.0",
+    "balena-sdk": "^12.12.0",
     "bluebird": "^3.5.0",
     "lodash": "^4.17.4",
     "mime": "^1.3.4",


### PR DESCRIPTION
Also limits travis to node v10, since gulp v3 doesn't work on node v12.
Bumping to gupl v4 wasn't trivial. Moreover it feels that we should better invest on refactoring to TS and drop gulp in favor of npm scripts, just like we do in other modules.

Resolves: #44
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>