### PR TITLE
Clone the incoming image stream before writing to disk

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -18,32 +18,28 @@ limitations under the License.
  * @module manager
  */
 
-import * as stream from 'stream';
 import { fromSharedOptions } from 'balena-sdk';
 import * as cache from './cache';
 import * as utils from './utils';
+import ReadableStreamClone from 'readable-stream-clone';
 
 const balena = fromSharedOptions();
 
 const doDownload = async (deviceType, version) => {
 	const imageStream = await balena.models.os.download(deviceType, version);
-	// Piping to a PassThrough stream is needed to be able
+
+	// Piping to a ReadableStreamClone stream is needed to be able
 	// to then pipe the stream to multiple destinations.
-	const pass = new stream.PassThrough();
-	imageStream.pipe(pass);
+	const pass = new ReadableStreamClone(imageStream);
+	const pass2 = new ReadableStreamClone(imageStream);
 
 	// Save a copy of the image in the cache
 	const cacheStream = await cache.getImageWritableStream(deviceType, version);
 
+	// Pipe the first cloned stream to the cache
 	pass.pipe(cacheStream);
 	pass.on('end', cacheStream.persistCache);
 
-	// If we return `pass` directly, the client will not be able
-	// to read all data from it after a delay, since it will be
-	// instantly piped to `cacheStream`.
-	// The solution is to create yet another PassThrough stream,
-	// pipe to it and return the new stream instead.
-	const pass2 = new stream.PassThrough();
 	// @ts-ignore adding an extra prop
 	pass2.mime = imageStream.mime;
 	imageStream.on('progress', (state) => pass2.emit('progress', state));
@@ -53,7 +49,12 @@ const doDownload = async (deviceType, version) => {
 		pass2.emit('error', err);
 	});
 
-	return pass.pipe(pass2);
+	pass.on('error', async (_) => {
+		await cacheStream.removeCache();
+	});
+
+	// Return the second cloned stream as output
+	return pass2;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "balena-sdk": "^15.2.1",
     "mime": "^2.4.6",
     "mkdirp": "^1.0.4",
+    "readable-stream-clone": "0.0.7",
     "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
This should prevent backpressure and out-of-sync disk write
speeds from backing up the entire pipeline and killing the stream.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>