### PR TITLE
Prevent the cacheStream from closing the other passthrough

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -35,7 +35,7 @@ const doDownload = async (deviceType, version) => {
 	// Save a copy of the image in the cache
 	const cacheStream = await cache.getImageWritableStream(deviceType, version);
 
-	pass.pipe(cacheStream);
+	pass.pipe(cacheStream, { end: false });
 	pass.on('end', cacheStream.persistCache);
 
 	// If we return `pass` directly, the client will not be able


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-io/balena-cli/issues/2152