### PR TITLE
Update balena-sdk to v16 and allow selecting OS variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Documentation
 
 
 * [manager](#module_manager)
-    * [.get(deviceType, versionOrRange)](#module_manager.get) ⇒ <code>Promise.&lt;NodeJS.ReadableStream&gt;</code>
+    * [.get(deviceType, versionOrRange, options)](#module_manager.get) ⇒ <code>Promise.&lt;NodeJS.ReadableStream&gt;</code>
     * [.cleanCache()](#module_manager.cleanCache) ⇒ <code>Promise</code>
 
 <a name="module_manager.get"></a>
 
-### manager.get(deviceType, versionOrRange) ⇒ <code>Promise.&lt;NodeJS.ReadableStream&gt;</code>
+### manager.get(deviceType, versionOrRange, options) ⇒ <code>Promise.&lt;NodeJS.ReadableStream&gt;</code>
 This function saves a copy of the downloaded image in the cache directory setting specified in [balena-settings-client](https://github.com/balena-io-modules/balena-settings-client).
 
 **Kind**: static method of [<code>manager</code>](#module_manager)  
@@ -48,6 +48,8 @@ This function saves a copy of the downloaded image in the cache directory settin
 | --- | --- | --- |
 | deviceType | <code>String</code> | device type slug or alias |
 | versionOrRange | <code>String</code> | can be one of * the exact version number, in which case it is used if the version is supported, or the promise is rejected, * a [semver](https://www.npmjs.com/package/semver)-compatible range specification, in which case the most recent satisfying version is used if it exists, or the promise is rejected, * `'latest'` in which case the most recent version is used, including pre-releases, * `'recommended'` in which case the recommended version is used, i.e. the most recent version excluding pre-releases, the promise is rejected if only pre-release versions are available, * `'default'` in which case the recommended version is used if available, or `latest` is used otherwise. Defaults to `'latest'`. |
+| options | <code>Object</code> |  |
+| options?.developmentMode | <code>boolean</code> |  |
 
 **Example**  
 ```js

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -27,8 +27,12 @@ export { isESR, resolveVersion, validateVersion } from './utils';
 
 const balena = fromSharedOptions();
 
-const doDownload = async (deviceType, version) => {
-	const imageStream = await balena.models.os.download(deviceType, version);
+const doDownload = async (deviceType, version, options) => {
+	const imageStream = await balena.models.os.download(
+		deviceType,
+		version,
+		options,
+	);
 	// Piping to a PassThrough stream is needed to be able
 	// to then pipe the stream to multiple destinations.
 	const pass = new stream.PassThrough();
@@ -81,13 +85,15 @@ const doDownload = async (deviceType, version) => {
  * * `'default'` in which case the recommended version is used if available,
  * or `latest` is used otherwise.
  * Defaults to `'latest'`.
+ * @param {Object} options
+ * @param {boolean} options?.developmentMode
  * @returns {Promise<NodeJS.ReadableStream>} image readable stream
  *
  * @example
  * manager.get('raspberry-pi', 'default').then (stream) ->
  * 	stream.pipe(fs.createWriteStream('foo/bar.img'))
  */
-export async function get(deviceType, versionOrRange) {
+export async function get(deviceType, versionOrRange, options = {}) {
 	if (versionOrRange == null) {
 		versionOrRange = 'latest';
 	}
@@ -95,7 +101,7 @@ export async function get(deviceType, versionOrRange) {
 	const isFresh = await cache.isImageFresh(deviceType, version);
 	const $stream = isFresh
 		? await cache.getImage(deviceType, version)
-		: await doDownload(deviceType, version);
+		: await doDownload(deviceType, version, options);
 	// schedule the 'version' event for the next iteration of the event loop
 	// so that callers have a chance of adding an event handler
 	setImmediate(() =>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,12 +62,11 @@ export function getDeviceType(deviceType) {
  * @returns {Promise<String>} the most recent compatible version.
  */
 export async function resolveVersion(deviceType, versionOrRange) {
-	const version = isESR(versionOrRange)
-		? versionOrRange
-		: await balena.models.os.getMaxSatisfyingVersion(
-				deviceType,
-				versionOrRange,
-		  );
+	const version = await balena.models.os.getMaxSatisfyingVersion(
+		deviceType,
+		versionOrRange,
+		isESR(versionOrRange) ? 'esr' : 'default',
+	);
 	if (!version) {
 		throw new Error('No such version for the device type');
 	}

--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
     "prepare": "npm run build",
     "readme": "jsdoc2md --template doc/README.hbs lib/manager.js > README.md"
   },
-  "author": "Juan Cruz Viotti <juan@balena.io>",
+  "author": "Balena Inc. (https://balena.io/)",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "devDependencies": {
     "@balena/lint": "^5.1.0",
     "@types/mime": "^2.0.3",
@@ -51,7 +54,7 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "balena-sdk": "^15.2.1",
+    "balena-sdk": "^16.8.0",
     "mime": "^2.4.6",
     "mkdirp": "^1.0.4",
     "rimraf": "^3.0.2"


### PR DESCRIPTION
Add support for the unified balenaOS versioning scheme (where dev/prod variants are not part of the semver), which requires balena SDK v16.7.0 or later. Used in the new major version of the balena CLI (v13).

Change-type: major
See: https://www.flowdock.com/app/rulemotion/r-architecture/threads/YN4RClMOz6v6W-VCfoqBaNoliFZ
See: https://www.flowdock.com/app/rulemotion/i-cli/threads/hdlxb8LTwYxQ8os3tFciOvh0CwD
See: (Arch Call recording) https://drive.google.com/file/d/11HRi1r63dLiOHCl40-XkGeEQoxvvk_jr/view
