### PR TITLE
Update README part for linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ Contribute
 - Issue Tracker: [github.com/balena-io-modules/balena-image-manager/issues](https://github.com/balena-io-modules/balena-image-manager/issues)
 - Source Code: [github.com/balena-io-modules/balena-image-manager](https://github.com/balena-io-modules/balena-image-manager)
 
-Before submitting a PR, please make sure that you include tests, and that [coffeelint](http://www.coffeelint.org/) runs without any warning:
+Before submitting a PR, please make sure that you include tests, and that linting runs without any warning:
 
 ```sh
-$ gulp lint
+$ npm run lint
 ```
 
 License

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "require-npm4-to-publish": "^1.0.0",
     "string-to-stream": "^1.1.1",
     "tmp": "0.0.31",
-    "typescript": "^3.9.7"
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "balena-sdk": "^16.8.0",


### PR DESCRIPTION
That's mostly in order to trigger a republish
of the npm package.

Change-type: patch